### PR TITLE
ci(workflow): bump third-party actions to latest major

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-24.04 # Pin version to match Dockerfile
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
 
       - name: Install dependencies
         run: |
@@ -37,7 +37,7 @@ jobs:
         run: bash src/resource/asm/make.bash
 
       - name: Upload artifacts
-        uses: actions/upload-artifact@v6
+        uses: actions/upload-artifact@v7
         with:
           name: books
           path: release/latest/
@@ -49,13 +49,13 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - name: Download artifacts
-        uses: actions/download-artifact@v6
+        uses: actions/download-artifact@v8
         with:
           name: books
           path: release/latest/
 
       - name: Upload to Release
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@v3
         with:
           files: |
             release/latest/ProgrammingGroundUp.pdf


### PR DESCRIPTION
## Summary

Bumps the third-party GitHub Actions used in `.github/workflows/release.yml` to their current floating major versions. No other workflow changes.

| Action | Old | New |
|---|---|---|
| actions/checkout | @v6 | @v7 |
| actions/upload-artifact | @v6 | @v7 |
| actions/download-artifact | @v6 | @v8 |
| softprops/action-gh-release | @v2 | @v3 |

## Why

The previous majors were behind on current fixes and the upstream `actions/*` lines (v7/v8) plus `softprops/action-gh-release` v3 have moved to the Node 24 Actions runtime, which Ubuntu 24.04 GitHub-hosted runners already ship. Staying on a current major avoids accumulating drift and keeps the workflow on supported runtimes.

No API-breaking changes apply to this workflow:

- `actions/upload-artifact@v7` still supports `name` + `path` + `retention-days: 7` (used as-is).
- `actions/download-artifact@v8` still supports `name` + `path` (used as-is). The new `skip-decompress` / `digest-mismatch` knobs are opt-in.
- `softprops/action-gh-release@v3` keeps the same `files` + `GITHUB_TOKEN` input surface.
- `actions/checkout@v7` keeps the default `repository` + `ref` behavior used here.

## Verification

- Branched off the default branch (`main`).
- `actionlint -color .github/workflows/release.yml` runs clean (no warnings or errors).
- GPG-signed via the global `commit.gpgsign=true`; the commit shows as `G` (good signature) both locally and on the remote:
  `git log --pretty="%H %G? %s" origin/main..HEAD` -> `3c0ae32e02b5faebef4d465bb125f5a171344e12 G ci(workflow): bump ...`
- Each bumped floating major was confirmed against the upstream `releases/latest` API:
  - `actions/checkout` -> v7.0.0
  - `actions/upload-artifact` -> v7.0.1
  - `actions/download-artifact` -> v8.0.1
  - `softprops/action-gh-release` -> v3.0.1