### PR TITLE
ci(workflow): pin all external actions to SHA and add Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,15 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    groups:
+      actions:
+        patterns: ["actions/*"]
+      third-party:
+        patterns: ["*"]
+        exclude-patterns: ["actions/*"]
+    commit-message:
+      prefix: "ci"
+    labels: ["dependencies", "ci"]

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-24.04 # Pin version to match Dockerfile
     steps:
       - name: Checkout code
-        uses: actions/checkout@v7
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
       - name: Install dependencies
         run: |
@@ -37,7 +37,7 @@ jobs:
         run: bash src/resource/asm/make.bash
 
       - name: Upload artifacts
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: books
           path: release/latest/
@@ -49,13 +49,13 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - name: Download artifacts
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: books
           path: release/latest/
 
       - name: Upload to Release
-        uses: softprops/action-gh-release@v3
+        uses: softprops/action-gh-release@718ea10b132b3b2eba29c1007bb80653f286566b # v3.0.1
         with:
           files: |
             release/latest/ProgrammingGroundUp.pdf


### PR DESCRIPTION
Pin all external GitHub Actions in `release.yml` to immutable commit SHAs. Add Dependabot for weekly auto-updates.

Closes #11